### PR TITLE
feat: Add ignoreWords parameter to folder-naming-convention rule

### DIFF
--- a/docs/rules/folder-naming-convention.md
+++ b/docs/rules/folder-naming-convention.md
@@ -113,6 +113,36 @@ Customizes the error message displayed when a folder does not match the naming p
 - `{{ target }}`: Represents the target folder.
 - `{{ pattern }}`: Represents the naming pattern for the target folder.
 
+##### `ignoreWords`
+
+An array of folder names to ignore during naming convention validation. Folders whose names exactly match any string in this array will be skipped and not validated against the naming pattern.
+
+```js
+export default [
+  {
+    plugins: {
+      'check-file': checkFile,
+    },
+    rules: {
+      'check-file/folder-naming-convention': [
+        'error',
+        {
+          'src/**/': 'CAMEL_CASE',
+          'mocks/*/': 'KEBAB_CASE',
+        },
+        {
+          errorMessage:
+            'The folder "{{ target }}" does not match the "{{ pattern }}" pattern, see contribute.md for details',
+          ignoreWords: ['skip_word_a', 'skip_word_b'],
+        },
+      ],
+    },
+  },
+];
+```
+
+With this configuration, folders named `skip_word_a` or `skip_word_b` will not be validated against the naming pattern, allowing paths like `mocks/skip_word_a/app-mock.ts` to pass validation even though `skip_word_a` doesn't follow the `KEBAB_CASE` pattern.
+
 ```js
 export default [
   {

--- a/lib/rules/folder-naming-convention.js
+++ b/lib/rules/folder-naming-convention.js
@@ -48,6 +48,10 @@ export default {
         type: 'object',
         properties: {
           errorMessage: { type: 'string' },
+          ignoreWords: {
+            type: 'array',
+            items: { type: 'string' },
+          },
         },
       },
     ],
@@ -81,6 +85,7 @@ export default {
       const filenameWithPath = getFilePath(context);
       const folderPath = getFolderPath(filenameWithPath);
       const errorMessage = context.options[1]?.errorMessage ?? '';
+      const ignoreWords = context.options[1]?.ignoreWords ?? [];
 
       for (const [folderPattern, namingPattern] of Object.entries(rules)) {
         if (
@@ -100,6 +105,11 @@ export default {
             .reduce((s, p) => s.concat(getAllFolders(p)), []);
 
           for (const folder of folders) {
+            // Skip validation if the folder name is in the ignore list
+            if (ignoreWords.includes(folder)) {
+              continue;
+            }
+
             if (
               !micromatch.isMatch(
                 folder,

--- a/package-lock.json
+++ b/package-lock.json
@@ -495,12 +495,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
-      "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
+      "version": "0.20.0",
+      "resolved": "https://bnpm.byted.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.4",
+        "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -508,20 +509,35 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.2.2",
+      "resolved": "https://bnpm.byted.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
       "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://bnpm.byted.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.1",
+      "resolved": "https://bnpm.byted.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -542,9 +558,10 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "resolved": "https://bnpm.byted.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -558,34 +575,42 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://bnpm.byted.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
-      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "version": "9.27.0",
+      "resolved": "https://bnpm.byted.org/@eslint/js/-/js-9.27.0.tgz",
+      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "version": "2.1.6",
+      "resolved": "https://bnpm.byted.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
-      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
+      "version": "0.3.1",
+      "resolved": "https://bnpm.byted.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.14.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -641,10 +666,11 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.3",
+      "resolved": "https://bnpm.byted.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -1267,9 +1293,10 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://bnpm.byted.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1454,9 +1481,10 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://bnpm.byted.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
@@ -1690,21 +1718,23 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
-      "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
+      "version": "9.27.0",
+      "resolved": "https://bnpm.byted.org/eslint/-/eslint-9.27.0.tgz",
+      "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.9.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.17.0",
-        "@eslint/plugin-kit": "^0.2.3",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.27.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -1712,7 +1742,7 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
+        "eslint-scope": "^8.3.0",
         "eslint-visitor-keys": "^4.2.0",
         "espree": "^10.3.0",
         "esquery": "^1.5.0",
@@ -1931,10 +1961,11 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.3.0",
+      "resolved": "https://bnpm.byted.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -2044,9 +2075,10 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://bnpm.byted.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -2316,9 +2348,10 @@
     },
     "node_modules/globals": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "resolved": "https://bnpm.byted.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2853,9 +2886,10 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "resolved": "https://bnpm.byted.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },

--- a/tests/lib/rules/folder-naming-convention.posix.js
+++ b/tests/lib/rules/folder-naming-convention.posix.js
@@ -659,3 +659,55 @@ ruleTester.run(
     ],
   }
 );
+
+ruleTester.run(
+  "folder-naming-convention with option: [{ 'mocks/**/': 'KEBAB_CASE' }, { ignoreWords: ['skip_word_a', 'skip_word_b'] }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'mocks/skip_word_a/app-mock.ts',
+        options: [
+          { 'mocks/**/': 'KEBAB_CASE' },
+          { ignoreWords: ['skip_word_a', 'skip_word_b'] },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'mocks/skip_word_b/another-mock.ts',
+        options: [
+          { 'mocks/**/': 'KEBAB_CASE' },
+          { ignoreWords: ['skip_word_a', 'skip_word_b'] },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'mocks/valid-kebab-case/mock.ts',
+        options: [
+          { 'mocks/**/': 'KEBAB_CASE' },
+          { ignoreWords: ['skip_word_a', 'skip_word_b'] },
+        ],
+      },
+    ],
+
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'mocks/InvalidCamelCase/mock.ts',
+        options: [
+          { 'mocks/**/': 'KEBAB_CASE' },
+          { ignoreWords: ['skip_word_a', 'skip_word_b'] },
+        ],
+        errors: [
+          {
+            message:
+              'The folder "InvalidCamelCase" does not match the "KEBAB_CASE" pattern',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);

--- a/tests/lib/rules/folder-naming-convention.windows.js
+++ b/tests/lib/rules/folder-naming-convention.windows.js
@@ -662,3 +662,55 @@ ruleTester.run(
     ],
   }
 );
+
+ruleTester.run(
+  "folder-naming-convention with option: [{ 'mocks/**/': 'KEBAB_CASE' }, { ignoreWords: ['skip_word_a', 'skip_word_b'] }]",
+  rule,
+  {
+    valid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'mocks\\skip_word_a\\app-mock.ts',
+        options: [
+          { 'mocks/**/': 'KEBAB_CASE' },
+          { ignoreWords: ['skip_word_a', 'skip_word_b'] },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'mocks\\skip_word_b\\another-mock.ts',
+        options: [
+          { 'mocks/**/': 'KEBAB_CASE' },
+          { ignoreWords: ['skip_word_a', 'skip_word_b'] },
+        ],
+      },
+      {
+        code: "var foo = 'bar';",
+        filename: 'mocks\\valid-kebab-case\\mock.ts',
+        options: [
+          { 'mocks/**/': 'KEBAB_CASE' },
+          { ignoreWords: ['skip_word_a', 'skip_word_b'] },
+        ],
+      },
+    ],
+
+    invalid: [
+      {
+        code: "var foo = 'bar';",
+        filename: 'mocks\\InvalidCamelCase\\mock.ts',
+        options: [
+          { 'mocks/**/': 'KEBAB_CASE' },
+          { ignoreWords: ['skip_word_a', 'skip_word_b'] },
+        ],
+        errors: [
+          {
+            message:
+              'The folder "InvalidCamelCase" does not match the "KEBAB_CASE" pattern',
+            column: 1,
+            line: 1,
+          },
+        ],
+      },
+    ],
+  }
+);


### PR DESCRIPTION
This PR adds a new ignoreWords configuration parameter to the folder-naming-convention rule, allowing users to specify folder names that should be exempt from naming convention validation.

Motivation
In some projects, certain folder names need to be preserved for compatibility, legacy reasons, or external requirements, even if they don't follow the project's naming conventions. For example, you might want to enforce KEBAB_CASE for most folders but allow specific folders like skip_word_a to bypass this validation.